### PR TITLE
Fix for non-roku devices responding to multicast

### DIFF
--- a/src/rokuclient/RokuClient.cs
+++ b/src/rokuclient/RokuClient.cs
@@ -63,7 +63,7 @@ namespace RokuDeviceLib
                         DeviceResponse = Encoding.ASCII.GetString(result.Buffer);
                     
                         var match = Regex.Match(DeviceResponse,LOCATION_PATTERN,RegexOptions.IgnoreCase);
-                        if(match.Success)
+                        if(match.Success && DeviceResponse.ToLower().Contains("roku"))
                         {
                             var address = match.Groups["address"].Value;
                             //Don't allow device info request to hold up discovering additional devices


### PR DESCRIPTION
I ran into some trouble recently due to other multicast devices (a Hue Hub, in my case) responding to the multicast when discovering devices.  When the discovery code attempts to pull details, it throws a 404 for the parsed address for those devices, which fails the discovery.

I also created a VS solution for your project with a test of the discovery added, if you'd like that as well.

Thanks, your project has made mine (Alexa/local control server) much easier!